### PR TITLE
HTTP header improvements

### DIFF
--- a/src/library/base/man/options.Rd
+++ b/src/library/base/man/options.Rd
@@ -650,9 +650,11 @@ getOption(x, default = NULL)
       HTTP(S) requests by \code{\link{download.file}}, \code{\link{url}}
       and \code{\link{curlGetHeaders}}, or \code{NULL} when requests will
       be made without a user agent header.  The default is
-      \code{R (<version> <platform> <arch> <os>)}
-      except when \samp{libcurl} is used when it is
-      \code{libcurl/7.<xx>.<y>} for the \samp{libcurl} version in use.}
+      \code{R (<version> <platform> <arch> <os> <download-method>)}.
+      If the \env{R_HTTP_USER_AGENT} environment variable is set, it is used
+      to initialize the option, with the \code{\%R} string replaced by
+      \code{<version> <platform> <arch> <os>}. The \code{\%M} string is
+      replaced by the download method, when the HTTP request is made.}
 
     \item{\code{install.lock}:}{logical: should per-directory package
       locking be used by \code{\link{install.packages}}?  Most useful

--- a/src/library/utils/R/readhttp.R
+++ b/src/library/utils/R/readhttp.R
@@ -32,17 +32,20 @@ defaultUserAgent <- function()
     Rver <- paste(R.version$major, R.version$minor, sep=".")
     Rdetails <- paste(Rver, R.version$platform, R.version$arch,
                       R.version$os)
-    paste0("R (", Rdetails, ")")
+    gsub("%R", Rdetails, Sys.getenv("R_HTTP_USER_AGENT", "R (%R %M)"))
 }
 
 
-makeUserAgent <- function(format = TRUE) {
+makeUserAgent <- function(format = TRUE, method = NULL) {
     agent <- getOption("HTTPUserAgent")
-    if (is.null(agent)) {
+    if (is.null(agent) || identical(agent, "")) {
         return(NULL)
     }
     if (length(agent) != 1L)
         stop(gettextf("%s option must be a length one character vector or NULL",
                       sQuote("HTTPUserAgent")), domain = NA)
+
+    if (!is.null(method)) agent[1L] <- gsub("%M", method, agent[1L])
+
     if (format) paste0("User-Agent: ", agent[1L], "\r\n") else agent[1L]
 }

--- a/src/library/utils/R/unix/download.file.R
+++ b/src/library/utils/R/unix/download.file.R
@@ -61,8 +61,15 @@ download.file <-
 		   stop("'destfile' must be a length-one character vector");
 	       if(quiet) extra <- c(extra, "--quiet")
 	       if(!cacheOK) extra <- c(extra, "--cache=off")
+	       if(!is.null(headers)) {
+                   headers <- paste0(nh, ": ", headers)
+                   headers <- paste0("--header=", shQuote(headers), collapse = " ")
+               }
+               ua <- c(makeUserAgent(FALSE, "wget"), "")[1]
 	       status <- system(paste("wget",
-				      paste(extra, collapse = " "),
+                                      "-U", shQuote(ua),
+                                      headers,
+                                      paste(extra, collapse = " "),
 				      shQuote(url),
 				      "-O", shQuote(path.expand(destfile))))
                if(status) stop("'wget' call had nonzero exit status")
@@ -74,8 +81,15 @@ download.file <-
 		   stop("'destfile' must be a length-one character vector");
 	       if(quiet) extra <- c(extra, "-s -S")
 	       if(!cacheOK) extra <- c(extra, paste("-H", shQuote("Pragma: no-cache")))
+	       if(!is.null(headers)) {
+                   headers <- paste0(nh, ": ", headers)
+                   headers <- paste0("--header ", shQuote(headers), collapse = " ")
+               }
+               ua <- c(makeUserAgent(FALSE, "curl"), "")[1]
 	       status <- system(paste("curl",
-				      paste(extra, collapse = " "),
+                                      "-A", shQuote(ua),
+                                      headers,
+                                      paste(extra, collapse = " "),
 				      shQuote(url),
 				      " -o", shQuote(path.expand(destfile))))
                if(status) stop("'curl' call had nonzero exit status")

--- a/src/library/utils/R/windows/download.file.R
+++ b/src/library/utils/R/windows/download.file.R
@@ -63,7 +63,14 @@ download.file <-
 		   stop("'destfile' must be a length-one character vector");
 	       if(quiet) extra <- c(extra, "--quiet")
 	       if(!cacheOK) extra <- c(extra, "--cache=off")
+	       if(!is.null(headers)) {
+                   headers <- paste0(nh, ": ", headers)
+                   headers <- paste0("--header=", shQuote(headers), collapse = " ")
+               }
+               ua <- c(makeUserAgent(FALSE, "wget"), "")[1]
 	       status <- system(paste("wget",
+                                      "-U", shQuote(ua),
+                                      headers,
 				      paste(extra, collapse = " "),
 				      shQuote(url),
 				      "-O", shQuote(path.expand(destfile))))
@@ -76,7 +83,14 @@ download.file <-
 		   stop("'destfile' must be a length-one character vector");
 	       if(quiet) extra <- c(extra, "-s -S")
 	       if(!cacheOK) extra <- c(extra, paste("-H", shQuote("Pragma: no-cache")))
+	       if(!is.null(headers)) {
+                   headers <- paste0(nh, ": ", headers)
+                   headers <- paste0("--header ", shQuote(headers), collapse = " ")
+               }
+               ua <- c(makeUserAgent(FALSE, "curl"), "")[1]
 	       status <- system(paste("curl",
+                                      "-A", shQuote(ua),
+                                      headers,
 				      paste(extra, collapse = " "),
 				      shQuote(url),
 				      " -o", shQuote(path.expand(destfile))))

--- a/src/modules/internet/internet.c
+++ b/src/modules/internet/internet.c
@@ -119,7 +119,7 @@ static Rboolean url_open(Rconnection con)
 	SEXP sagent, agentFun;
 	const char *agent;
 	SEXP s_makeUserAgent = install("makeUserAgent");
-	agentFun = PROTECT(lang1(s_makeUserAgent)); // defaults to ,TRUE
+	agentFun = PROTECT(lang3(s_makeUserAgent, ScalarLogical(1), mkString("internal")));
 	SEXP utilsNS = PROTECT(R_FindNamespace(mkString("utils")));
 	struct urlconn *uc = con->private;
 	sagent = eval(agentFun, utilsNS);
@@ -247,7 +247,7 @@ static Rboolean url_open2(Rconnection con)
 	const char *agent;
 	SEXP s_makeUserAgent = install("makeUserAgent");
 	struct urlconn * uc = con->private;
-	agentFun = PROTECT(lang2(s_makeUserAgent, ScalarLogical(0)));
+	agentFun = PROTECT(lang3(s_makeUserAgent, ScalarLogical(0), mkString("internal")));
 	sagent = PROTECT(eval(agentFun, R_FindNamespace(mkString("utils"))));
 	if(TYPEOF(sagent) == NILSXP)
 	    agent = NULL;
@@ -562,11 +562,11 @@ static SEXP in_do_download(SEXP args)
 #ifdef Win32
 	R_FlushConsole();
 	if(meth)
-	    agentFun = PROTECT(lang2(install("makeUserAgent"), ScalarLogical(0)));
+            agentFun = PROTECT(lang3(install("makeUserAgent"), ScalarLogical(0), mkString("wininet")));
 	else
-	    agentFun = PROTECT(lang1(install("makeUserAgent")));
+            agentFun = PROTECT(lang3(install("makeUserAgent"), ScalarLogical(1), mkString("internal")));
 #else
-	agentFun = PROTECT(lang1(install("makeUserAgent")));
+	agentFun = PROTECT(lang3(install("makeUserAgent"), ScalarLogical(1), mkString("internal")));
 #endif
 	SEXP utilsNS = PROTECT(R_FindNamespace(mkString("utils")));
 	sagent = eval(agentFun, utilsNS);

--- a/src/modules/internet/libcurl.c
+++ b/src/modules/internet/libcurl.c
@@ -236,35 +236,22 @@ static void curlCommon(CURL *hnd, int redirect, int verify)
 	curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYHOST, 0L);
 	curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 0L);
     }
-#if 0
     // for consistency, but all utils:::makeUserAgent does is look up an option.
+    char curlver[20];
+    curl_version_info_data *d = curl_version_info(CURLVERSION_NOW);
+    snprintf(curlver, 20, "libcurl/%s", d->version);
     SEXP sMakeUserAgent = install("makeUserAgent");
-    SEXP agentFun = PROTECT(lang2(sMakeUserAgent, ScalarLogical(0)));
+    SEXP agentFun = PROTECT(lang3(sMakeUserAgent, ScalarLogical(0), mkString(curlver)));
     SEXP utilsNS = PROTECT(R_FindNamespace(mkString("utils")));
     SEXP sua = eval(agentFun, utilsNS);
     UNPROTECT(1); /* utilsNS */
     PROTECT(sua);
-    if(TYPEOF(sua) != NILSXP)
-	curl_easy_setopt(hnd, CURLOPT_USERAGENT, CHAR(STRING_ELT(sua, 0)));
+
+    if (!Rf_isNull(sua)) {
+        curl_easy_setopt(hnd, CURLOPT_USERAGENT, CHAR(STRING_ELT(sua, 0)));
+    }
     UNPROTECT(2);
-#else
-    int Default = 1;
-    SEXP sua = GetOption1(install("HTTPUserAgent")); // set in utils startup
-    if (TYPEOF(sua) == STRSXP && LENGTH(sua) == 1 ) {
-	const char *p = CHAR(STRING_ELT(sua, 0));
-	if (p[0] && p[1] && p[2] && p[0] == 'R' && p[1] == ' ' && p[2] == '(') {
-	} else {
-	    Default = 0;
-	    curl_easy_setopt(hnd, CURLOPT_USERAGENT, p);
-	}
-    }
-    if (Default) {
-	char buf[20];
-	curl_version_info_data *d = curl_version_info(CURLVERSION_NOW);
-	snprintf(buf, 20, "libcurl/%s", d->version);
-	curl_easy_setopt(hnd, CURLOPT_USERAGENT, buf);
-    }
-#endif
+
     int timeout0 = asInteger(GetOption1(install("timeout")));
     long timeout = timeout0 = NA_INTEGER ? 0 : 1000L * timeout0;
     curl_easy_setopt(hnd, CURLOPT_CONNECTTIMEOUT_MS, timeout);


### PR DESCRIPTION
* Use the `HTTPUserAgent` option for `wget`/`curl` download methods as well, 
  in `download.file()`. If the user agent is also added via the extra options,
  that takes precedence.
* Use the `headers` argument for the `wget` and `curl` methods, in
  `download.file()`. If headers are also specified via the extra options,
  those take precedence.
* Do not send the User-Agent header if HTTPUserAgent is NULL,
  as documented. Previously some methods did send this header.
* Use R_HTTP_USER_AGENT env var to set the user agent default.
  And replace %R with the R version, platform, arch and os tuple.
  The default is set when the utils package is loaded, like before.
* Include the download method in the default user agent header.
  For the libcurl method this includes the version number as well.
