### PR TITLE
Omit \Sexpr[stage=render] warning in install for top level

### DIFF
--- a/src/library/tools/tests/rd.R
+++ b/src/library/tools/tests/rd.R
@@ -1,0 +1,21 @@
+require(tools)
+
+# -------------------------------------------------------------------
+# prepare_Rd() is OK with a top level \Sexpr that is yet to be rendered
+
+txt <- "
+\\name{foo}
+\\title{Title}
+\\description{Desc.}
+\\Sexpr[stage=render,results=rd]{\"\\\\\\details{This is dynamic.}\"}
+"
+
+rd <- tools::parse_Rd(con <- textConnection(txt)); close(con)
+
+warn <- NULL
+withCallingHandlers(
+  rd2 <- tools:::prepare_Rd(rd),
+  warning = function(w) { warn <<- w; invokeRestart("muffleWarning") }
+)
+stopifnot(is.null(warn))
+stopifnot("\\Sexpr" %in% tools:::RdTags(rd2))


### PR DESCRIPTION
Currently, if a package has

    \Sexpr[stage=render,results=rd]{"\\\\examples{foo()}"}

then `R CMD INSTALL` (and thus `R CMD check` as well) reports a
warning, because `\Sexpr{}` is not considered to be a legitimate
top level section:

    Warning: dynextest.Rd:14: Section \Sexpr is unrecognized and will be dropped

However, `\Sexpr{}` as a top level section is ok, if the dynamic
code is executed at render time.

This patch omits the warning for these cases.

Bug report is here: https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17623