### PR TITLE
Allow \Sexpr in \examples in wide line check, if installed

### DIFF
--- a/src/library/tools/R/QC.R
+++ b/src/library/tools/R/QC.R
@@ -8406,7 +8406,7 @@ function(dir, limit = c(usage = 95, examples = 105), installed = FALSE)
         Rd_db(basename(dir), lib.loc = dirname(dir))
     else
         Rd_db(dir = dir)
-    out <- find_wide_Rd_lines_in_Rd_db(db, limit)
+    out <- find_wide_Rd_lines_in_Rd_db(db, limit, installed)
     class(out) <- "check_Rd_line_widths"
     attr(out, "limit") <- limit
     out
@@ -8455,20 +8455,21 @@ function(x, ...)
 }
 
 find_wide_Rd_lines_in_Rd_db <-
-function(x, limit = NULL)
+function(x, limit = NULL, installed = FALSE)
 {
-    y <- lapply(x, find_wide_Rd_lines_in_Rd_object, limit)
+    y <- lapply(x, find_wide_Rd_lines_in_Rd_object, limit, installed)
     Filter(length, y)
 }
 
 find_wide_Rd_lines_in_Rd_object <-
-function(x, limit = NULL)
+function(x, limit = NULL, installed = FALSE)
 {
     if(is.null(limit))
         limit <- list(usage = c(79, 95), examples = c(87, 105))
     sections <- names(limit)
     if(is.null(sections))
         stop("no Rd sections specified")
+    if (installed) x <- prepare_Rd(x, stages = "render")
     y <- Map(function(s, l) {
         out <- NULL
         zz <- textConnection("out", "w", local = TRUE)

--- a/src/library/tools/tests/qc.R
+++ b/src/library/tools/tests/qc.R
@@ -1,0 +1,34 @@
+require("tools")
+
+# -------------------------------------------------------------------
+# find_wide_Rd_lines_in_Rd_object: render stage=render \Sexpr
+# expressions within \examples if installed = TRUE.
+
+rd <- sprintf("
+\\name{foo}
+\\title{Title}
+\\description{Desc.}
+\\examples{
+  \\Sexpr[stage=render]{\"# foobar\"}
+  \\Sexpr[stage=render]{strrep(\"long \", 30)}
+  # %s
+}", strrep("123456789 ", 10))
+
+rd <- tools::parse_Rd(con <- textConnection(rd)); close(con)
+
+# does not error, but finds long lines, dynamic ones as well
+bad <- tools:::find_wide_Rd_lines_in_Rd_object(rd, installed = TRUE)
+stopifnot(
+  "examples" %in% names(bad),
+  "warn" %in% names(bad$examples),
+  any(grepl("123456789 ", bad$examples$warn)),
+  any(grepl("long ", bad$examples$warn))
+)
+
+# does error currently
+err <- NULL
+tryCatch(
+  tools:::find_wide_Rd_lines_in_Rd_object(rd, installed = FALSE),
+  error = function(e) err <<- e
+)
+stopifnot(!is.null(err))


### PR DESCRIPTION
For installed = FALSE, we still get an error.