### PR TITLE
Link to topics, not files

### DIFF
--- a/doc/manual/R-exts.texi
+++ b/doc/manual/R-exts.texi
@@ -6923,22 +6923,16 @@ given above.
 There are two other forms of optional argument specified as
 @code{\link[@var{pkg}]@{@var{foo}@}} and
 @code{\link[@var{pkg:bar}]@{@var{foo}@}} to link to the package
-@pkg{@var{pkg}}, to @emph{files} @file{@var{foo}.html} and
-@file{@var{bar}.html} respectively.  These are rarely needed, perhaps to
-refer to not-yet-installed packages (but there the @HTML{} help system
-will resolve the link at run time) or in the normally undesirable event
-that more than one package offers help on a topic@footnote{a common
-example in @acronym{CRAN} packages is @code{\link[mgcv]@{gam@}}.} (in
-which case the present package has precedence so this is only needed to
-refer to other packages).  They are currently only used in @HTML{} help
-(and ignored for hyperlinks in @LaTeX{} conversions of help pages), and
-link to the file rather than the topic (since there is no way to know
-which topics are in which files in an uninstalled package).  The
-@strong{only} reason to use these forms for base and recommended
-packages is to force a reference to a package that might be further down
-the search path.  Because they have been frequently misused, the @HTML{}
-help system looks for topic @code{@var{foo}} in package @pkg{@var{pkg}}
-if it does not find file @file{@var{foo}.html}.
+@pkg{@var{pkg}}, to @emph{topics} @var{foo} and @var{bar} respectively.
+While the @HTML{} help system automatically searches for topics in the
+loaded packages, it is good practice to specify packages explicitly,
+to reduce the risk that the incorrect help file is shown.
+
+Previously @code{\link[@var{pkg}]@{@var{foo}@}} and
+@code{\link[@var{pkg:bar}]@{@var{foo}@}} could only link to @emph{files}
+@file{@var{foo}.html} and @file{@var{bar}.html}.  For compatibility
+reasons the @HTML{} help system still picks up these files first, before
+searching for the topics.
 
 Packages referred to by these `other forms' should be declared in the
 @file{DESCRIPTION} file, in the @samp{Depends}, @samp{Imports},

--- a/src/library/tools/R/QC.R
+++ b/src/library/tools/R/QC.R
@@ -4466,13 +4466,6 @@ function(package, dir, lib.loc = NULL)
                             paste(sQuote(undeclared), collapse = ", "),
                             domain = NA))
     }
-
-    mind_suspects <-
-        config_val_to_logical(Sys.getenv("_R_CHECK_XREFS_MIND_SUSPECT_ANCHORS_",
-                                         "FALSE"))
-    if(mind_suspects) {
-        db <- cbind(db, suspect = FALSE)
-    }
     
     for (pkg in anchors) {
         ## we can't do this on the current uninstalled package!
@@ -4489,8 +4482,6 @@ function(package, dir, lib.loc = NULL)
                 !good & (thisfile[this] %in% aliases1)
             } else FALSE
             db[this, "bad"] <- !good & !suspect
-            if(mind_suspects)
-                db[this, "suspect"] <- suspect
             
         } else if(use_aliases_from_CRAN) {
             if(is.null(aliases_db)) {
@@ -4512,8 +4503,6 @@ function(package, dir, lib.loc = NULL)
                 !good & (thisfile[this] %in% aliases1)
             } else FALSE
             db[this, "bad"] <- !good & !suspect
-            if(mind_suspects)
-                db[this, "suspect"] <- suspect
         }
         else
             unknown <- c(unknown, pkg)
@@ -4548,37 +4537,25 @@ function(package, dir, lib.loc = NULL)
     }
     ## The bad ones:
     bad <- db[, "bad"] == "TRUE"
-    out <- list(bad = split(db[bad, "report"], db[bad, "File"]))
-    if(mind_suspects && any(ind <- db[, "suspect"] == "TRUE")) {
-        out <- c(out, list(suspect = split(db[ind, "report"],
-                                           db[ind, "File"])))
-    }
-    structure(out, class = "check_Rd_xrefs")
+    res1 <- split(db[bad, "report"], db[bad, 3L])
+    structure(list(bad = res1), class = "check_Rd_xrefs")
 }
 
 format.check_Rd_xrefs <-
 function(x, ...)
 {
-    xb <- x$bad
-    xs <- x$suspect
-    if(length(xb) || length(xs)) {
-        .fmtb <- function(i) {
+    xx <- x$bad
+    if(length(xx)) {
+        .fmt <- function(i) {
             c(gettextf("Missing link or links in documentation object '%s':",
-                       names(xb)[i]),
+                       names(xx)[i]),
               ## NB, link might be empty, and was in mvbutils
-              .pretty_format(unique(xb[[i]])),
+              .pretty_format(unique(xx[[i]])),
               "")
         }
-        .fmts <- function(i) {
-            c(gettextf("Non-file package-anchored link(s) in documentation object '%s':",
-                       names(xs)[i]),
-              .pretty_format(unique(xs[[i]])),
-              "")
-        }
-        c(unlist(lapply(seq_along(xb), .fmtb)),
-          unlist(lapply(seq_along(xs), .fmts)),
-          strwrap(gettextf("See section 'Cross-references' in the 'Writing R Extensions' manual."))
-          )
+        c(unlist(lapply(seq_along(xx), .fmt)),
+          strwrap(gettextf("See section 'Cross-references' in the 'Writing R Extensions' manual.")),
+          "")
     } else {
         character()
     }

--- a/src/library/tools/R/Rd2HTML.R
+++ b/src/library/tools/R/Rd2HTML.R
@@ -373,13 +373,7 @@ Rd2HTML <-
                 if (!OK) {
                     ## so how about as a topic?
                     file <- utils:::index.search(parts$targetfile, pkgpath)
-                    if (length(file)) {
-                        warnRd(block, Rdfile,
-                               "file link ", sQuote(parts$targetfile),
-                               " in package ", sQuote(parts$pkg),
-                               " does not exist and so has been treated as a topic")
-                        parts$targetfile <- basename(file)
-                    } else {
+                    if (length(file) == 0) {
                         warnRd(block, Rdfile, "missing file link ",
                                sQuote(parts$targetfile))
                     }

--- a/src/library/tools/R/check.R
+++ b/src/library/tools/R/check.R
@@ -6121,7 +6121,6 @@ add_dummies <- function(dir, Log)
         Sys.setenv("_R_CHECK_DEPENDS_ONLY_DATA_" = "TRUE")
         Sys.setenv("_R_OPTIONS_STRINGS_AS_FACTORS_" = "FALSE")
 ##        Sys.setenv("_R_CHECK_XREFS_PKGS_ARE_DECLARED_" = "TRUE")
-        Sys.setenv("_R_CHECK_XREFS_MIND_SUSPECT_ANCHORS_" = "TRUE")
         R_check_vc_dirs <- TRUE
         R_check_executables_exclusions <- FALSE
         R_check_doc_sizes2 <- TRUE


### PR DESCRIPTION
1. Rd2HTML does not warn any more for linking to topics.
2. R CMD check does not warn any more for linking to topics.
3. Updated WRE.